### PR TITLE
add TencentCloud api

### DIFF
--- a/conf/evaluate_conf.go
+++ b/conf/evaluate_conf.go
@@ -95,4 +95,10 @@ var CloudAPI = []cloudAPIS{
 		ResponseMatch: "deviceName",
 		DocURL:        "https://cloud.google.com/compute/docs/storing-retrieving-metadata",
 	},
+	{
+		CloudProvider: "Tencent Cloud",
+		API:           "http://metadata.tencentyun.com/latest/meta-data/",
+		ResponseMatch: "instance-name",
+		DocURL:        "https://cloud.tencent.com/document/product/213/4934",
+	},
 }


### PR DESCRIPTION
Output in tencentcloud:
```
➜  ~ ./cdk_test evaluate
[Discovery - Cloud Provider Metadata API]
2021/01/25 15:11:11 failed to dial Alibaba Cloud API.
2021/01/25 15:11:12 failed to dial Azure API.
2021/01/25 15:11:13 failed to dial Google Cloud API.
	Tencent Cloud Metadata API available in http://metadata.tencentyun.com/latest/meta-data/
	Docs: https://cloud.tencent.com/document/product/213/4934
➜  ~ curl http://metadata.tencentyun.com/latest/meta-data/
app-id
instance-id
local-ipv4
mac
public-ipv4
uuid
instance-name
placement/
payment/
network/
instance/
ntp/#
```
