### PR TITLE
fix: check ptrace by capeff

### DIFF
--- a/pkg/exploit/check_ptrace.go
+++ b/pkg/exploit/check_ptrace.go
@@ -3,87 +3,44 @@ package exploit
 import (
 	"github.com/cdk-team/CDK/pkg/plugin"
 	"github.com/cdk-team/CDK/pkg/tool/ps"
+	"io/ioutil"
 	"log"
-	"os"
-	"runtime"
-	"syscall"
+	"regexp"
+	"strconv"
 )
 
-type Event interface{}
+const sysPtraceCapMask uint64 = 2 << 18
 
-type Tracee struct {
-	proc   *os.Process
-	events chan Event
-	err    chan error
-
-	cmds chan func()
-}
-
-func PtraceExec(name string, argv []string) (*Tracee, error) {
-	t := &Tracee{
-		events: make(chan Event, 1),
-		err:    make(chan error, 1),
-		cmds:   make(chan func()),
-	}
-
-	err := make(chan error)
-	proc := make(chan *os.Process)
-	go func() {
-		runtime.LockOSThread()
-		p, e := os.StartProcess(name, argv, &os.ProcAttr{
-			Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
-			Sys: &syscall.SysProcAttr{
-				Ptrace: true,
-			},
-		})
-		proc <- p
-		err <- e
-		if e != nil {
-			return
-		}
-		go t.wait()
-		t.trace()
-	}()
-	t.proc = <-proc
-	return t, <-err
-}
-
-func (t *Tracee) wait() {
-	defer close(t.events)
-	for {
-		state, err := t.proc.Wait()
-		if err != nil {
-			t.err <- err
-			return
-		}
-		if state.Exited() {
-			t.events <- Event(state.Sys().(syscall.WaitStatus))
-			return
-		}
-		t.events <- Event(state.Sys().(syscall.WaitStatus))
-	}
-}
-
-func (t *Tracee) trace() {
-	for cmd := range t.cmds {
-		cmd()
-	}
+func enableSysPtraceCap(mask uint64) bool {
+	return mask&sysPtraceCapMask != 0
 }
 
 func CheckPidInject() bool {
-	cmd := "/bin/echo"
-	arg := []string{
-		"1",
-	}
-	t, err := PtraceExec(cmd, arg)
+	data, err := ioutil.ReadFile("/proc/self/status")
 	if err != nil {
-		log.Println("exec ptrace failed. err:", err)
+		log.Println(err)
 		return false
-	} else {
-		log.Println("exec ptrace success.", t.events)
-		ps.RunPs()
-		return true
 	}
+
+	pattern := regexp.MustCompile("(?i)capeff:\\s*?([a-z0-9]+)\\s")
+	params := pattern.FindAllStringSubmatch(string(data), 1)
+
+	for _, matched := range params {
+		mask, err := strconv.ParseUint(matched[1], 16, 64)
+		if err != nil {
+			log.Println(err)
+			return false
+		}
+		if enableSysPtraceCap(mask) {
+			log.Println("SYS_PTRACE capability was enabled.")
+			ps.RunPs()
+			return true
+		} else {
+			log.Println("SYS_PTRACE capability was disabled.")
+			return false
+		}
+	}
+	return false
 }
 
 // plugin interface

--- a/pkg/exploit/check_ptrace_test.go
+++ b/pkg/exploit/check_ptrace_test.go
@@ -1,0 +1,18 @@
+package exploit
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var EnableSysPtraceCap = enableSysPtraceCap
+
+func TestCheckPidInject(t *testing.T) {
+	CheckPidInject()
+}
+
+func TestCheckSysPtraceCap(t *testing.T) {
+	assert.False(t, EnableSysPtraceCap(0x00000000a80425fb))
+	assert.True(t, EnableSysPtraceCap(0x0000003fffffffff))
+	assert.True(t, EnableSysPtraceCap(0x00000000a80c25fb))
+}


### PR DESCRIPTION
原先的check-ptrace似乎无论是否添加`--cap-add=SYS_PTRACE`参数启动的容器都显示success
![image](https://user-images.githubusercontent.com/30930379/107147247-f3664780-6987-11eb-9625-d65e2e8443b3.png)

修改后通过读取`/proc/self/status`中`CapEff`的值判断是否开启SYS_PTRACE Capability