### PR TITLE
fix repeated `Authorization` http header

### DIFF
--- a/pkg/tool/kubectl/common.go
+++ b/pkg/tool/kubectl/common.go
@@ -88,9 +88,6 @@ func ServerAccountRequest(opts K8sRequestOption) (string, error) {
 	if err != nil {
 		return "", &errors.CDKRuntimeError{Err: err, CustomMsg: "err found while generate post request in net.http ."}
 	}
-	if len(token) > 0 {
-		request.Header.Set("Authorization", "Bearer "+token)
-	}
 
 	// set request header
 	if opts.Method == "POST" {


### PR DESCRIPTION
repeated set for `Authorization` header in `pkg/tool/kubectl/common.go:91`:

![image](https://user-images.githubusercontent.com/11347901/110625398-55f67180-81da-11eb-8901-1143b9099c24.png)
