### PR TITLE
switch parameter positions in k8s-backdoor-daemonset script

### DIFF
--- a/pkg/exploit/k8s_backdoor_daemonset.go
+++ b/pkg/exploit/k8s_backdoor_daemonset.go
@@ -95,7 +95,7 @@ func DeployBackdoorDaemonset(serverAddr string, tokenPath string, image string, 
 		opts.TokenPath = tokenPath
 	}
 
-	log.Printf("trying to deploy daemonset with image:%s to k8s-app:%s", k8sApp, image)
+	log.Printf("trying to deploy daemonset with image:%s to k8s-app:%s", image, k8sApp)
 	opts.PostData = getBackDoorDaemonsetJson(k8sApp, image, inputArgs)
 	resp, err := kubectl.ServerAccountRequest(opts)
 	if err != nil {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/40566803/113476111-e2c7de80-94ab-11eb-9349-5d25e7dd5d05.png)
The parameters in `log.Printf` at line 98 should be switched: 
https://github.com/cdk-team/CDK/blob/a39c03f276d82e4c366fe1ac9bd7ecbcf471d6fd/pkg/exploit/k8s_backdoor_daemonset.go#L98
