### PR TITLE
修复cap_dac_read_search poc中存在的文件截断以及EOF问题 

### DIFF
--- a/pkg/exploit/cap_dac_read_search.go
+++ b/pkg/exploit/cap_dac_read_search.go
@@ -56,7 +56,6 @@ func init() {
 	plugin.RegisterExploit("cap-dac-read-search", exploit)
 }
 
-
 // http://stealth.openwall.net/xSports/shocker.c
 // some code borrowed from https://golang.org/src/os
 
@@ -271,14 +270,21 @@ func CapDacReadSearchExploit(target, ref string) error {
 		log.Fatalf("[-] OpenByHandleAt: %v\n", err)
 	}
 	file := os.NewFile(uintptr(fd), "")
-	if err != nil {
-		log.Fatalf("[-] os.NewFile: %v\n", err)
-	}
-	out := make([]byte, 1024)
-	if _, err := file.ReadAt(out, 0); err != nil {
-		log.Fatalf("[-] Read: %v\n", err)
-	}
 	defer file.Close()
+
+	out := make([]byte, 4096)
+	buf := make([]byte, 1024)
+	for {
+		n, err := file.Read(buf)
+		if n == 0 {
+			break
+		}
+		if err != nil {
+			log.Fatalf("[-] Read: %v\n", err)
+		}
+		out = append(out, buf[:n]...)
+	}
+
 	fmt.Println(string(out))
 
 	return nil


### PR DESCRIPTION
原本的file.ReadAt(out, 0)只会读取out长度的字节，也就是1024
就会导致当文件长度超过1024时文件产生截断，文件长度小于1024时产生EOF异常
![117273988-3a80ad80-ae8f-11eb-8a4d-6bfb641a60db](https://user-images.githubusercontent.com/30930379/117276855-df9c8580-ae91-11eb-9a0e-099519ff964b.png)

修复后可以正常读取文件的所有内容
![117274040-43717f00-ae8f-11eb-9a25-b7031e53efca](https://user-images.githubusercontent.com/30930379/117276922-f0e59200-ae91-11eb-8eab-0f29a5295994.png)
