### PR TITLE
Add check for `CAP_SYS_MODULE` and `CAP_DAC_READ_SEARCH`

### DIFF
--- a/pkg/evaluate/available_linux_capabilities.go
+++ b/pkg/evaluate/available_linux_capabilities.go
@@ -27,6 +27,20 @@ func GetProcCapabilities() bool {
 		if len(lst) == 2 {
 			capStr := strings.TrimSpace(lst[1])
 			fmt.Printf("\tCap decode: 0x%s = %s\n", capStr, capability.CapHexToText(capStr))
+
+			caps, err := capability.CapHexParser(capStr)
+			if err != nil {
+				log.Printf("[-] capability.CapHexParser: %v\n", err)
+				return false
+			}
+			for _, c := range caps {
+				switch c {
+				case "CAP_DAC_READ_SEARCH":
+					fmt.Printf("[!] CAP_DAC_READ_SEARCH enabled. You can read files from host. Use 'cdk run cap-dac-read-search' ... for exploitation.")
+				case "CAP_SYS_MODULE":
+					fmt.Printf("[!] CAP_SYS_MODULE enabled. You can escape the container via loading kernel module. More info at https://xcellerator.github.io/posts/docker_escape/.")
+				}
+			}
 		}
 
 		if strings.Contains(matched, "3fffffffff") {


### PR DESCRIPTION
Hi team,

1. In this PR I've added explicit check for `CAP_SYS_MODULE` (and `CAP_DAC_READ_SERACH` as well) at evaluate step. This way it's more clear for end-user what escape techniques he / she can apply after evaluate step is completed.
1. I suggest to refactor [check_ptrace.go](https://github.com/cdk-team/CDK/blob/main/pkg/exploit/check_ptrace.go) in similar way because technically it's just evaluating that `CAP_SYS_PTRACE` exists and not actually escaping. So I suppose it should belong to evaluate step rather than escape step.
1. The reason why I didn't implement actual `CAP_SYS_MODULE` escape in CDK is because each kernel version and architecture combination requires kernel module built specifically for it. Given how many kernel versions and architectures out there I see several options:
    1. To make detailed instructions on how to build kernel module for arbitrary kernel version and architecture and put them to CDK.
    1. To prebuilt kernel module for most popular distributions (e.g. Ubuntu 20.04) include them in CDK binary and leave note on how to build kernel module for other kernel versions.
4. What do you think about point (3)? Do you have any ideas on how to integrate `CAP_SYS_MODULE` escape to CDK?

---

Nikita Stupin
Advanced Software Technology Lab
Huawei