### PR TITLE
fix #71 (exp): k8s-shadow-apiserver check apiserver error in invalid …

### DIFF
--- a/pkg/exploit/k8s_shadow_apiserver.go
+++ b/pkg/exploit/k8s_shadow_apiserver.go
@@ -61,7 +61,7 @@ func findApiServerPodInMasterNode(token string, serverAddr string) (string, erro
 		log.Printf("request apiserver uri `%s` error: %v, response: %s", opts.Api, err, resp)
 		return "", errors.New("faild to request api-server.")
 	}
-	if !strings.Contains(resp, "selfLink") {
+	if !strings.Contains(resp, "selfLink") && !strings.Contains(resp, "kube-apiserver") {
 		log.Println("api-server response:")
 		fmt.Println(resp)
 		return "", errors.New("invalid to list pods, possible caused by api-server forbidden this request.")


### PR DESCRIPTION
…to list pods