### PR TITLE
feat(evaluate): get namespace for current service account, and list the permissions of that

### DIFF
--- a/pkg/exploit/k8s_cronjob.go
+++ b/pkg/exploit/k8s_cronjob.go
@@ -1,5 +1,5 @@
+//go:build !no_k8s_cronjob
 // +build !no_k8s_cronjob
-
 
 /*
 Copyright 2022 The Authors of https://github.com/CDK-TEAM/CDK .
@@ -99,7 +99,7 @@ func deployK8sCronjob(serverAddr string, tokenPath string, image string, inputAr
 	log.Println("requesting ", cronJobAPI)
 	resp, err := kubectl.ServerAccountRequest(opts)
 	if err != nil {
-		return "", errors.New("faild to request api-server.")
+		return "", errors.New("fail to request api-server.")
 	}
 	if !strings.Contains(resp, "selfLink") {
 		log.Println("api-server response:")


### PR DESCRIPTION
In normal circumstances, the SA (Service Account) associated with the current container has a high probability of manipulating the Pod containers within the current namespace. However, the CDK (Continuous Deployment Kit) process may result in the inability to obtain the namespace. 

Attackers can leak the namespace name through errors and then use 'auth can-i' to review their permissions for the namespace. More details in code and [article](https://hpdoger.cn/2023/06/20/title:%20%E5%AF%B9Kubernetes%20RBAC%E6%8E%88%E6%9D%83%E9%98%B2%E5%BE%A1&%E6%94%BB%E5%87%BB%E7%9A%84%E9%83%A8%E5%88%86%E6%80%9D%E8%80%83/#%E5%90%8E%E6%B8%97%E9%80%8F%E5%88%A9%E7%94%A8)