### PR TITLE
fix: fix miss makezero bug

### DIFF
--- a/pkg/evaluate/cgroups.go
+++ b/pkg/evaluate/cgroups.go
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2022 The Authors of https://github.com/CDK-TEAM/CDK .
 
@@ -27,7 +26,7 @@ import (
 func DumpCgroup() {
 
 	cgroupLst, err := util.GetCgroup(1)
-	sLst := make([]string, len(cgroupLst))
+	sLst := make([]string, 0, len(cgroupLst))
 
 	if err != nil {
 		log.Printf("/proc/1/cgroup error: %v\n", err)

--- a/pkg/util/cgroup.go
+++ b/pkg/util/cgroup.go
@@ -82,7 +82,7 @@ func GetMountInfo() ([]MountInfo, error) {
 		ret = append(ret, strings.Trim(line, "\n"))
 	}
 	// 2346 2345 0:261 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
-	mountInfos := make([]MountInfo, len(ret))
+	mountInfos := make([]MountInfo, 0, len(ret))
 
 	for _, r := range ret {
 		parts := strings.Split(r, " - ")


### PR DESCRIPTION
I was running github actions to run linter [makezero](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1

and the github actions output https://github.com/alingse/go-linter-runner/actions/runs/9242680355/job/25425806374 

```
====================================================================================================
append to slice `mountInfos` with non-zero initialized length at https://github.com/cdk-team/CDK/blob/main/pkg/util/cgroup.go#L130:16
append to slice `ret` with non-zero initialized length at https://github.com/cdk-team/CDK/blob/main/pkg/util/cgroup.go#L1[9](https://github.com/alingse/go-linter-runner/actions/runs/9242680355/job/25425806374#step:4:10)0:9
append to slice `sLst` with non-zero initialized length at https://github.com/cdk-team/CDK/blob/main/pkg/evaluate/cgroups.go#L40:[10](https://github.com/alingse/go-linter-runner/actions/runs/9242680355/job/25425806374#step:4:11)
====================================================================================================
```

the `mountInfos` and `sLst` is easy to check they are bugs , but `ret` is hard to fix, so I do not commit it.

```go
// get kernel version
func GetKernelVersion() ([]int, error) {
	utsInfo := &unix.Utsname{}
	err := unix.Uname(utsInfo)
	if err != nil {
		return nil, err
	}
	relStr := string(utsInfo.Release[:])
	relIdx := strings.Index(relStr, "-")
	if relIdx == -1 {
		return nil, errors.New("unknown internal error when executing uname")
	}
	ret := make([]int, 3)
	for _, v := range strings.Split(relStr[:relIdx], ".") {
		verData, err := strconv.Atoi(v)
		if err != nil {
			return nil, err
		}
		ret = append(ret, verData)
	}
	return ret, nil
}
```
if we update `ret := make([]int, 3)` to `ret := make([]int, 0, 3)`

the GetKernelVersion may got  ret with length less 3, if the user use index to operate it, may got some error, 🤔 

so you can choose fix it or not.
