### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/evaluate/cgroups.go
+++ b/pkg/evaluate/cgroups.go
@@ -27,7 +27,7 @@ import (
 func DumpCgroup() {
 
 	cgroupLst, err := util.GetCgroup(1)
-	sLst := make([]string, len(cgroupLst))
+	sLst := make([]string, 0, len(cgroupLst))
 
 	if err != nil {
 		log.Printf("/proc/1/cgroup error: %v\n", err)


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of len(cgroupLst) rather than initializing the length of this slice.