### PR TITLE
kcurl anonymous mode，add random ip addresses to confuse ip addresses

### DIFF
--- a/pkg/tool/kubectl/common.go
+++ b/pkg/tool/kubectl/common.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"net/http"
 	"os"
@@ -158,6 +159,20 @@ func ServerAccountRequest(opts K8sRequestOption) (string, error) {
 	if len(opts.Token) > 0 {
 		token := strings.TrimSpace(opts.Token)
 		request.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	// Anonymous mode，add random ip addresses to confuse ip addresses
+	if opts.Anonymous {
+		rand.Seed(time.Now().UnixNano())
+		ips := make([]string, 100)
+
+		for i := 0; i < 100; i++ {
+			ip := fmt.Sprintf("10.%d.%d.%d", rand.Intn(256), rand.Intn(256), rand.Intn(256))
+			ips[i] = ip
+		}
+
+		randIpStr := strings.Join(ips, ",")
+		request.Header.Set("X-Forwarded-For", randIpStr)
 	}
 
 	resp, err := client.Do(request)


### PR DESCRIPTION
kcurl anonymous mode，add random ip addresses to confuse ip addresses

<img width="962" alt="image" src="https://github.com/user-attachments/assets/ea8d57fe-cfb1-4db6-b13c-cd697ea74e4b">

Reference document: https://mp.weixin.qq.com/s?__biz=MzU1NzkwMzUzNg==&mid=2247484194&idx=1&sn=85c96519682c0bf127c3fd23fc6cd572&chksm=fc2ff8f dcb5871eb6c5a9ad250f1c18f5b2249604405ca900c98f9503f56f4ca98e94b201af8&token=928588215&lang=zh_CN