### PR TITLE
modify k8s service account functions

### DIFF
--- a/pkg/evaluate/evaluate.go
+++ b/pkg/evaluate/evaluate.go
@@ -17,8 +17,8 @@ limitations under the License.
 package evaluate
 
 import (
+	"fmt"
 	"github.com/cdk-team/CDK/pkg/util"
-	"github.com/cdk-team/CDK/conf"
 )
 
 // CallBasics is a function to call basic functions
@@ -51,7 +51,17 @@ func CallBasics() {
 	CheckK8sAnonymousLogin()
 
 	util.PrintH2("Discovery - K8s Service Account")
-	CheckPrivilegedK8sServiceAccount(conf.K8sSATokenDefaultPath)
+
+	path := GetDefaultK8SAccountInfo()
+	address, err := GetKubernetesAddress()
+
+	if err != nil {
+		fmt.Println("Error:", err)
+	} else {
+		fmt.Println("KUBERNETES_PORT_443_TCP_ADDR:", address)
+	}
+
+	CheckPrivilegedK8sServiceAccount(path, address)
 
 	util.PrintH2("Discovery - Cloud Provider Metadata API")
 	CheckCloudMetadataAPI()


### PR DESCRIPTION
看了一下 CDK 这里的判断 k8s service token 是用的硬编码（默认配置文件），这种方式不太精确，所以修改了一下。同样在对 k8s api server 发起请求的时候，默认的 ServerIP 是空，这里用 env 去取环境变量，增加了一个逻辑