### PR TITLE
modify k8s service account functions_2

### DIFF
--- a/pkg/evaluate/evaluate.go
+++ b/pkg/evaluate/evaluate.go
@@ -17,7 +17,6 @@ limitations under the License.
 package evaluate
 
 import (
-	"fmt"
 	"github.com/cdk-team/CDK/pkg/util"
 )
 
@@ -52,16 +51,7 @@ func CallBasics() {
 
 	util.PrintH2("Discovery - K8s Service Account")
 
-	path := GetDefaultK8SAccountInfo()
-	address, err := GetKubernetesAddress()
-
-	if err != nil {
-		fmt.Println("Error:", err)
-	} else {
-		fmt.Println("KUBERNETES_PORT_443_TCP_ADDR:", address)
-	}
-
-	CheckPrivilegedK8sServiceAccount(path, address)
+	CheckPrivilegedK8sServiceAccount(GetDefaultK8SAccountInfo(), GetKubernetesAddress())
 
 	util.PrintH2("Discovery - Cloud Provider Metadata API")
 	CheckCloudMetadataAPI()

--- a/pkg/evaluate/evaluate.go
+++ b/pkg/evaluate/evaluate.go
@@ -17,8 +17,8 @@ limitations under the License.
 package evaluate
 
 import (
+	"fmt"
 	"github.com/cdk-team/CDK/pkg/util"
-	"github.com/cdk-team/CDK/conf"
 )
 
 // CallBasics is a function to call basic functions
@@ -51,7 +51,17 @@ func CallBasics() {
 	CheckK8sAnonymousLogin()
 
 	util.PrintH2("Discovery - K8s Service Account")
-	CheckPrivilegedK8sServiceAccount(conf.K8sSATokenDefaultPath)
+
+	path := GetDefaultK8SAccountInfo()
+	address, err := GetKubernetesAddress()
+
+	if err != nil {
+		fmt.Println("Error:", err)
+	} else {
+		fmt.Println("KUBERNETES_PORT_443_TCP_ADDR:", address)
+	}
+
+	CheckPrivilegedK8sServiceAccount(path, address)
 
 	util.PrintH2("Discovery - Cloud Provider Metadata API")
 	CheckCloudMetadataAPI()

--- a/pkg/task/auto_escape.go
+++ b/pkg/task/auto_escape.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cdk-team/CDK/pkg/exploit/persistence"
 	"log"
 
-	"github.com/cdk-team/CDK/conf"
 	"github.com/cdk-team/CDK/pkg/cli"
 	"github.com/cdk-team/CDK/pkg/evaluate"
 	"github.com/cdk-team/CDK/pkg/plugin"
@@ -109,7 +108,13 @@ func autoEscape(shellCommand string) bool {
 	// 4. check k8s anonymous login
 	fmt.Printf("\n[Auto Escape - K8s API Server]\n")
 	anonymousLogin := evaluate.CheckK8sAnonymousLogin()
-	privServiceAccount := evaluate.CheckPrivilegedK8sServiceAccount(conf.K8sSATokenDefaultPath)
+	defaultAccountInfo := GetDefaultK8SAccountInfo()
+	kubernetesAddress := GetKubernetesAddress()
+
+	privServiceAccount := evaluate.CheckPrivilegedK8sServiceAccount(
+		CheckPrivilegedK8sServiceAccount(defaultAccountInfo, kubernetesAddress),
+	)
+
 	k8sExploit = privServiceAccount || anonymousLogin
 
 	if !k8sExploit {


### PR DESCRIPTION
- 修改 k8s service account 取值的路径，通过读取 /proc/self/mountinfo，而不是原本的硬编码模式
- 修改探测 k8s api server 未授权时的 address 获取，通过拿环境变量的方式动态获取（原本为空）
- 由于新增了函数，auto_escape 部分逻辑也需要重新修改